### PR TITLE
Resolve issue with promise propagation

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,11 @@
   },
   "homepage": "https://github.com/redux-effects/redux-effects",
   "devDependencies": {
-    "babel-preset-es2015": "^6.3.13",
+    "babel-cli": "^6.7.5",
+    "babel-preset-es2015": "^6.6.0",
     "babel-tape-runner": "^2.0.0",
-    "redux": "^1.0.1",
-    "tape": "^4.2.0"
+    "redux": "^3.4.0",
+    "tape": "^4.5.1"
   },
   "dependencies": {
     "is-promise": "^2.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,10 @@ function effects ({dispatch, getState}) {
   }
 
   function applyPromises (steps = [], q) {
-    return steps.reduce((q, [success = noop, failure = rethrow]) => q.then(val => maybeDispatch(success(val)), err => maybeDispatch(failure(err))), q)
+    return steps.reduce((q, [success = noop, failure = rethrow]) =>
+      q.then(
+        val => promisify(maybeDispatch(success(val))),
+        err => promisify(maybeDispatch(failure(err)))), q)
   }
 
   function maybeDispatch (action) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function effects ({dispatch, getState}) {
   }
 
   function applyPromises (steps = [], q) {
-    return steps.reduce((q, [success = noop, failure = noop]) => q.then(val => maybeDispatch(success(val)), err => maybeDispatch(failure(err))), q)
+    return steps.reduce((q, [success = noop, failure = rethrow]) => q.then(val => maybeDispatch(success(val)), err => maybeDispatch(failure(err))), q)
   }
 
   function maybeDispatch (action) {
@@ -42,6 +42,7 @@ function promisify (val) {
 }
 
 function noop () {}
+function rethrow (err) { throw err; }
 
 /**
  * Action creator

--- a/test/index.js
+++ b/test/index.js
@@ -25,6 +25,20 @@ test('should work', ({plan, equal}) => {
   }
 })
 
+test('unhandled rejections should pass through', ({plan, fail, pass}) => {
+  const store = create(effects, mw);
+
+  plan(1)
+  const promise = store.dispatch({type: 'EFFECT_COMPOSE', payload: {type: 'test'}, meta: {steps: [[x => x]]}})
+
+  promise.then(fail, pass);
+
+  function mw (api) {
+    return next => action =>
+      Promise.reject('alwaysReject')
+  }
+})
+
 /**
  * Helpers
  */


### PR DESCRIPTION
This PR resolves issue with promise propagation by calling promisify on maybeDispatch return values in promise handlers.

There's also slightly opinionated addition where default failure handler always rethrows, so that failures aren't just silently ignored.
